### PR TITLE
allow v12 and v13 of websockets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
-websockets = "^12.0"
+websockets = "websockets>=12.0,<14"
 aiohttp = "^3.7.4"
 msgpack = "^1.0.2"
 orjson = "^3.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
-websockets = "websockets>=12.0,<14"
+websockets = ">=12.0,<14"
 aiohttp = "^3.7.4"
 msgpack = "^1.0.2"
 orjson = "^3.9.0"


### PR DESCRIPTION
avoids dependency clash in downstream projects as described in this issue https://github.com/baking-bad/pysignalr/issues/23